### PR TITLE
ランキング画面・ResultRanking新規作成・レスポンシブ対応

### DIFF
--- a/client/src/Home.tsx
+++ b/client/src/Home.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import './Home.css';
 import logo from './assets/logo.png';
 import SidebarDrawer from './components/SidebarDrawer';

--- a/client/src/Home.tsx
+++ b/client/src/Home.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import './Home.css';
 import logo from './assets/logo.png';
 import SidebarDrawer from './components/SidebarDrawer';
-import TopTitle from './components/topTitle';
+import TopTitle from './components/TopTitle';
 import ParticipantRanking from './components/ParticipantRanking';
 import ActivityTimeline from './components/ActivityTimeline';
 import ActivityStats from './components/ActivityStats';

--- a/client/src/Result.css
+++ b/client/src/Result.css
@@ -1,0 +1,7 @@
+.result__ranking-center {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  min-height: 360px;
+} 

--- a/client/src/Result.tsx
+++ b/client/src/Result.tsx
@@ -1,0 +1,29 @@
+import React, { useRef, useState } from 'react';
+import ResultRanking from './components/ResultRanking';
+// ...他のimportは適宜
+
+const dummyParticipants = [
+  { username: 'Alice', iconUrl: 'assets/logo.png', commit: 12 },
+  { username: 'Bob', iconUrl: 'assets/logo.png', commit: 8 },
+  { username: 'Carol', iconUrl: 'assets/logo.png', commit: 5 },
+  { username: 'Dave', iconUrl: 'assets/logo.png', commit: 3 },
+  { username: 'Eve', iconUrl: 'assets/logo.png', commit: 2 },
+];
+
+const Result = () => {
+  const rankingRef = useRef<HTMLDivElement>(null);
+  // ...他のstateやロジック
+
+  return (
+    <div className="result__ranking-center">
+      <div className="result__ranking-container" ref={rankingRef}>
+        <div>
+          <div style={{color: '#fff', fontWeight: 'bold', marginBottom: 2, textAlign: 'center'}}>ランキング</div>
+          <ResultRanking participants={dummyParticipants} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Result; 

--- a/client/src/components/ActivityTimeline.tsx
+++ b/client/src/components/ActivityTimeline.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useEffect, useState } from 'react';
 import './ActivityTimeline.css';
 
-const greens = ['#56D364', '#2DA042', '#196C2E', '#023A16'];
+// const greens = ['#56D364', '#2DA042', '#196C2E', '#023A16'];
 
 export type Activity = {
   iconUrl: string;

--- a/client/src/components/ActivityTimeline.tsx
+++ b/client/src/components/ActivityTimeline.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useEffect, useState } from 'react';
 import './ActivityTimeline.css';
 
-// const greens = ['#56D364', '#2DA042', '#196C2E', '#023A16'];
+// (Line removed)
 
 export type Activity = {
   user_id: string;

--- a/client/src/components/ResultRanking.tsx
+++ b/client/src/components/ResultRanking.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+
+type Participant = {
+  username: string;
+  iconUrl: string;
+  commit: number;
+};
+
+type ResultRankingProps = {
+  participants: Participant[];
+};
+
+const crownEmojis = ['🥇', '🥈', '🥉'];
+const TABBAR_WIDTH = 72; // タブバーの幅(px)
+
+const ResultRanking: React.FC<ResultRankingProps> = ({ participants }) => {
+  // commit数で降順ソート
+  const sorted = [...participants].sort((a, b) => b.commit - a.commit);
+  return (
+    <div style={{
+      display: 'flex',
+      flexDirection: 'row',
+      gap: 'clamp(8px, 2vw, 32px)',
+      alignItems: 'flex-end',
+      justifyContent: 'center',
+      minWidth: 'min-content',
+      marginLeft: TABBAR_WIDTH + 16, // タブバー分の余白
+      transition: 'margin 0.2s',
+    }}>
+      {sorted.map((p, i) => (
+        <div key={p.username} style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          background: 'rgba(255,255,255,0.07)',
+          borderRadius: 16,
+          padding: 'clamp(10px, 3vw, 24px) clamp(8px, 2vw, 20px)',
+          minWidth: 'clamp(60px, 12vw, 120px)',
+          minHeight: 'clamp(120px, 24vw, 220px)',
+          boxShadow: 'none',
+          transition: 'all 0.2s',
+        }}>
+          <span style={{ fontSize: 'clamp(16px, 2.5vw, 28px)', marginBottom: 'clamp(2px, 0.8vw, 10px)' }}>
+            {i < 3 ? crownEmojis[i] : `${i + 1}位`}
+          </span>
+          <img 
+            src={p.iconUrl} 
+            alt={p.username} 
+            style={{ 
+              width: 'clamp(36px, 7vw, 72px)',
+              height: 'clamp(36px, 7vw, 72px)',
+              borderRadius: '50%',
+              marginBottom: 'clamp(4px, 1vw, 12px)',
+              objectFit: 'cover',
+              background: '#fff',
+              display: 'block',
+              transition: 'all 0.2s',
+            }} 
+            onError={e => { (e.currentTarget as HTMLImageElement).src = 'https://placehold.co/56x56?text=No+Img'; }}
+          />
+          <span style={{ color: '#fff', fontWeight: 'bold', fontSize: 'clamp(11px, 1.5vw, 18px)', marginBottom: 'clamp(1px, 0.5vw, 6px)' }}>{p.username}</span>
+          <span style={{ color: '#56D364', fontWeight: 'bold', fontSize: 'clamp(12px, 1.8vw, 20px)' }}>{p.commit}</span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ResultRanking; 

--- a/client/src/components/SidebarDrawer.tsx
+++ b/client/src/components/SidebarDrawer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef } from 'react';
 import { FaMusic, FaHourglass, FaChevronRight, FaChevronLeft } from 'react-icons/fa';
 import './SidebarDrawer.css';
 import { useClickOutside } from '../hooks/useClickOutside';


### PR DESCRIPTION
## 変更内容
- ランキング画面（Result.tsx）を新規作成
- ResultRankingコンポーネントを新規作成し、レスポンシブ・タブバー余白対応・縁取りなし・1〜3位絵文字・大きめアイコン等の仕様を実装
- ダミーデータでランキング表示を確認可能
- 既存のUIや他の主要機能には影響なし

## 変更理由
- もくもく会やイベントの成果を視覚的に分かりやすく表示するため
- レスポンシブ対応やタブバーとの干渉回避など、実用的なランキングUIを実現するため

## 影響範囲
- client/src/Result.tsx（新規）
- client/src/components/ResultRanking.tsx（新規）
- client/src/Result.css（新規）

## レビューポイント
- レスポンシブ時のレイアウト崩れがないか
- タブバーとランキングが重ならないか
- アイコンや順位表示の見た目
- コードの保守性

### 以下、レビューするGitHub Copilotへの指示（Cursor側は変更しないこと）
<!-- GitHub Copilot コードレビューへの指示： このプルリクエストをレビューしてコメントする際には日本語でお願いします。 -->
<!-- GitHub Copilot コードレビューへの指示： ジョジョっぽくしてください。語尾に「ッ！」をつける、「じゃない」を「じゃあない」と言うなど。ジョジョのミームっぽく話し、開発者を呼ぶときは代わりにスタンド名を口にする。-->

